### PR TITLE
fix: 修复ba本周生日中当日生日学生未正确显示的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -232,7 +232,7 @@ class Birthday(Star):
                 status = ""
                 if is_today:
                     status = "（🎉就在今天！）"
-                if is_past:
+                elif is_past:
                     status = "（已过）"
                 else:
                     status = "（未过）"


### PR DESCRIPTION
20250929 圣娅 未过
fix:20250929 圣娅 🎉就在今天！
（圣娅：AHHHH）
娅门